### PR TITLE
Add Vocello to open-source TTS table

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ If you are looking for **free text-to-speech models for commercial use** or want
 | **Parler-TTS** | Hugging Face | Lightweight, controllable speech generation with high naturalness. | Python | [HF](https://huggingface.co/parler-tts) |
 | **Matcha-TTS** | Shivam Mehta | Fast TTS architecture employing conditional flow matching, producing highly natural output. | Python | [![GitHub stars](https://img.shields.io/github/stars/shivammehta25/Matcha-TTS?style=social&color=white)](https://github.com/shivammehta25/Matcha-TTS/stargazers) |
 | **LocalMode** | LocalMode | **In-browser TTS.** Runs Kokoro (29 voices) and other AI models 100% in the browser via WebGPU/WASM. No server, no API keys, offline after first load. | JavaScript / TypeScript | [![GitHub stars](https://img.shields.io/github/stars/LocalMode-AI/LocalMode?style=social&color=white)](https://github.com/LocalMode-AI/LocalMode/stargazers) |
+| **Vocello** | PowerBeef | **Native Mac & iPhone app.** Qwen3-TTS with preset speakers, natural-language voice design, and voice cloning. Runs entirely on Apple Silicon with no Python runtime, faster than realtime on an 8 GB M2. | Swift / MLX | [![GitHub stars](https://img.shields.io/github/stars/PowerBeef/Vocello?style=social&color=white)](https://github.com/PowerBeef/Vocello/stargazers) |
 
 ### Advanced Voice Cloning & Neural Voice Synthesis 🧬
 


### PR DESCRIPTION
Native Swift + MLX app rather than a Python library, running Qwen3-TTS fully on-device on Apple Silicon. Preset speakers, describe-a-voice, and cloning, in ten languages. MIT licensed, signed and notarized.

Relevant to the ElevenLabs-alternatives framing in this README: no account, no character metering, and scripts are never uploaded.